### PR TITLE
C++ modernisation changes.

### DIFF
--- a/src/GamepadConfig.h
+++ b/src/GamepadConfig.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_CONFIG_H_
-#define GAMEPAD_CONFIG_H_
+#pragma once
 
 #ifndef DEFAULT_SOCD_MODE
 #define DEFAULT_SOCD_MODE SOCD_MODE_NEUTRAL
@@ -16,6 +15,4 @@
 
 #ifndef DEFAULT_INPUT_MODE
 #define DEFAULT_INPUT_MODE INPUT_MODE_XINPUT
-#endif
-
 #endif

--- a/src/GamepadDebouncer.cpp
+++ b/src/GamepadDebouncer.cpp
@@ -27,6 +27,6 @@ void GamepadDebouncer::debounce(GamepadState *state)
 		}
 	}
 
-	memcpy(&state->dpad, &debounceState.dpad, sizeof(uint8_t));
-	memcpy(&state->buttons, &debounceState.buttons, sizeof(uint16_t));
+	state->dpad = debounceState.dpad;
+	state->buttons = debounceState.buttons;
 }

--- a/src/GamepadDebouncer.h
+++ b/src/GamepadDebouncer.h
@@ -3,14 +3,14 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_DEBOUNCER_H_
-#define GAMEPAD_DEBOUNCER_H_
+#pragma once
 
 #include <string.h>
 #include <stdint.h>
 #include "GamepadState.h"
 
 // Implement this wrapper function for your platform
+// TODO: Make this a pure virtual member instead.
 uint32_t getMillis();
 
 class GamepadDebouncer
@@ -25,5 +25,3 @@ class GamepadDebouncer
 		uint32_t dpadTime[4];
 		uint32_t buttonTime[GAMEPAD_BUTTON_COUNT];
 };
-
-#endif

--- a/src/GamepadDescriptors.h
+++ b/src/GamepadDescriptors.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_DESCRIPTORS_H_
-#define GAMEPAD_DESCRIPTORS_H_
+#pragma once
 
 #include <string.h>
 #include "GamepadEnums.h"
@@ -138,5 +137,3 @@ static const uint16_t *getStringDescriptor(uint16_t *size, InputMode mode, uint8
 
 	return convertStringDescriptor(size, str, charCount);
 }
-
-#endif

--- a/src/GamepadEnums.h
+++ b/src/GamepadEnums.h
@@ -3,56 +3,56 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_ENUMS_H_
-#define GAMEPAD_ENUMS_H_
+#pragma once
 
 // The available input modes
-typedef enum
+// TODO: Think about making enums "class enum" instead. This will keep them out of the global namespace
+// and provide strong type assurance instead of being treated as ints. Also, modern c++ would tend towards
+// using Pascal-case naming for the individual declarations.
+enum InputMode
 {
 	INPUT_MODE_XINPUT,
 	INPUT_MODE_SWITCH,
 	INPUT_MODE_HID,
 	INPUT_MODE_CONFIG = 255,
-} InputMode;
+};
 
 // The available stick emulation modes
-typedef enum
+enum DpadMode
 {
 	DPAD_MODE_DIGITAL,
 	DPAD_MODE_LEFT_ANALOG,
 	DPAD_MODE_RIGHT_ANALOG,
-} DpadMode;
+};
 
 // The available SOCD cleaning methods
-typedef enum
+enum SOCDMode
 {
 	SOCD_MODE_UP_PRIORITY,           // U+D=U, L+R=N
 	SOCD_MODE_NEUTRAL,               // U+D=N, L+R=N
 	SOCD_MODE_SECOND_INPUT_PRIORITY, // U>D=D, L>R=R (Last Input Priority, aka Last Win)
-} SOCDMode;
+};
 
 // Enum for tracking last direction state of Second Input SOCD method
-typedef enum
+enum DpadDirection
 {
 	DIRECTION_NONE,
 	DIRECTION_UP,
 	DIRECTION_DOWN,
 	DIRECTION_LEFT,
 	DIRECTION_RIGHT
-} DpadDirection;
+};
 
 // The available hotkey actions
-typedef enum
+enum GamepadHotkey
 {
 	HOTKEY_NONE              = 0x00,
-	HOTKEY_DPAD_DIGITAL      = 0x01,
-	HOTKEY_DPAD_LEFT_ANALOG  = 0x02,
-	HOTKEY_DPAD_RIGHT_ANALOG = 0x04,
-	HOTKEY_HOME_BUTTON       = 0x08,
-	HOTKEY_CAPTURE_BUTTON    = 0x10,
-	HOTKEY_SOCD_UP_PRIORITY  = 0x20,
-	HOTKEY_SOCD_NEUTRAL      = 0x40,
-	HOTKEY_SOCD_LAST_INPUT   = 0x80,
-} GamepadHotkey;
-
-#endif
+	HOTKEY_DPAD_DIGITAL      = (1U << 0),
+	HOTKEY_DPAD_LEFT_ANALOG  = (1U << 1),
+	HOTKEY_DPAD_RIGHT_ANALOG = (1U << 2),
+	HOTKEY_HOME_BUTTON       = (1U << 3),
+	HOTKEY_CAPTURE_BUTTON    = (1U << 4),
+	HOTKEY_SOCD_UP_PRIORITY  = (1U << 5),
+	HOTKEY_SOCD_NEUTRAL      = (1U << 6),
+	HOTKEY_SOCD_LAST_INPUT   = (1U << 7),
+};

--- a/src/GamepadEnums.h
+++ b/src/GamepadEnums.h
@@ -58,5 +58,3 @@ enum GamepadHotkey
 	HOTKEY_INVERT_X_AXIS     = (1U << 8),
 	HOTKEY_INVERT_Y_AXIS     = (1U << 9),
 };
-
-#endif

--- a/src/GamepadOptions.h
+++ b/src/GamepadOptions.h
@@ -3,17 +3,14 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_OPTIONS_H_
-#define GAMEPAD_OPTIONS_H_
+#pragma once
 
 #include "GamepadEnums.h"
 
 struct GamepadOptions
 {
-	InputMode inputMode;
-	DpadMode dpadMode;
-	SOCDMode socdMode;
-	bool isSet;
+	InputMode inputMode {InputMode::INPUT_MODE_XINPUT}; 
+	DpadMode dpadMode {DpadMode::DPAD_MODE_DIGITAL};
+	SOCDMode socdMode {SOCDMode::SOCD_MODE_NEUTRAL};
+	bool isSet {false};
 };
-
-#endif

--- a/src/GamepadState.h
+++ b/src/GamepadState.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_STATE_H_
-#define GAMEPAD_STATE_H_
+#pragma once
 
 #include <stdint.h>
 #include "GamepadEnums.h"
@@ -34,32 +33,32 @@
 	+--------+--------+---------+----------+----------+--------+
 */
 
-#define GAMEPAD_MASK_UP    (1 << 0)
-#define GAMEPAD_MASK_DOWN  (1 << 1)
-#define GAMEPAD_MASK_LEFT  (1 << 2)
-#define GAMEPAD_MASK_RIGHT (1 << 3)
+#define GAMEPAD_MASK_UP    (1U << 0)
+#define GAMEPAD_MASK_DOWN  (1U << 1)
+#define GAMEPAD_MASK_LEFT  (1U << 2)
+#define GAMEPAD_MASK_RIGHT (1U << 3)
 
-#define GAMEPAD_MASK_B1    (1 << 0)
-#define GAMEPAD_MASK_B2    (1 << 1)
-#define GAMEPAD_MASK_B3    (1 << 2)
-#define GAMEPAD_MASK_B4    (1 << 3)
-#define GAMEPAD_MASK_L1    (1 << 4)
-#define GAMEPAD_MASK_R1    (1 << 5)
-#define GAMEPAD_MASK_L2    (1 << 6)
-#define GAMEPAD_MASK_R2    (1 << 7)
-#define GAMEPAD_MASK_S1    (1 << 8)
-#define GAMEPAD_MASK_S2    (1 << 9)
-#define GAMEPAD_MASK_L3    (1 << 10)
-#define GAMEPAD_MASK_R3    (1 << 11)
-#define GAMEPAD_MASK_A1    (1 << 12)
-#define GAMEPAD_MASK_A2    (1 << 13)
+#define GAMEPAD_MASK_B1    (1U << 0)
+#define GAMEPAD_MASK_B2    (1U << 1)
+#define GAMEPAD_MASK_B3    (1U << 2)
+#define GAMEPAD_MASK_B4    (1U << 3)
+#define GAMEPAD_MASK_L1    (1U << 4)
+#define GAMEPAD_MASK_R1    (1U << 5)
+#define GAMEPAD_MASK_L2    (1U << 6)
+#define GAMEPAD_MASK_R2    (1U << 7)
+#define GAMEPAD_MASK_S1    (1U << 8)
+#define GAMEPAD_MASK_S2    (1U << 9)
+#define GAMEPAD_MASK_L3    (1U << 10)
+#define GAMEPAD_MASK_R3    (1U << 11)
+#define GAMEPAD_MASK_A1    (1U << 12)
+#define GAMEPAD_MASK_A2    (1U << 13)
 
 // For detecting dpad as buttons
 
-#define GAMEPAD_MASK_DU    (1 << 16)
-#define GAMEPAD_MASK_DD    (1 << 17)
-#define GAMEPAD_MASK_DL    (1 << 18)
-#define GAMEPAD_MASK_DR    (1 << 19)
+#define GAMEPAD_MASK_DU    (1U << 16)
+#define GAMEPAD_MASK_DD    (1U << 17)
+#define GAMEPAD_MASK_DL    (1U << 18)
+#define GAMEPAD_MASK_DR    (1U << 19)
 
 #define GAMEPAD_MASK_DPAD (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)
 
@@ -95,15 +94,15 @@ const uint16_t buttonMasks[] =
 
 struct GamepadState
 {
-	uint8_t dpad;
-	uint16_t buttons;
-	uint16_t aux;
-	uint16_t lx;
-	uint16_t ly;
-	uint16_t rx;
-	uint16_t ry;
-	uint8_t lt;
-	uint8_t rt;
+	uint8_t dpad {0};
+	uint16_t buttons {0};
+	uint16_t aux {0};
+	uint16_t lx {GAMEPAD_JOYSTICK_MID};
+	uint16_t ly {GAMEPAD_JOYSTICK_MID};
+	uint16_t rx {GAMEPAD_JOYSTICK_MID};
+	uint16_t ry {GAMEPAD_JOYSTICK_MID};
+	uint8_t lt {0};
+	uint8_t rt {0};
 };
 
 // Convert the horizontal GamepadState dpad axis value into an analog value
@@ -111,12 +110,14 @@ inline uint16_t dpadToAnalogX(uint8_t dpad)
 {
 	switch (dpad & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT))
 	{
-	case GAMEPAD_MASK_LEFT:
-		return GAMEPAD_JOYSTICK_MIN;
-	case GAMEPAD_MASK_RIGHT:
-		return GAMEPAD_JOYSTICK_MAX;
-	default:
-		return GAMEPAD_JOYSTICK_MID;
+		case GAMEPAD_MASK_LEFT:
+			return GAMEPAD_JOYSTICK_MIN;
+
+		case GAMEPAD_MASK_RIGHT:
+			return GAMEPAD_JOYSTICK_MAX;
+
+		default:
+			return GAMEPAD_JOYSTICK_MID;
 	}
 }
 
@@ -125,12 +126,14 @@ inline uint16_t dpadToAnalogY(uint8_t dpad)
 {
 	switch (dpad & (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN))
 	{
-	case GAMEPAD_MASK_UP:
-		return GAMEPAD_JOYSTICK_MIN;
-	case GAMEPAD_MASK_DOWN:
-		return GAMEPAD_JOYSTICK_MAX;
-	default:
-		return GAMEPAD_JOYSTICK_MID;
+		case GAMEPAD_MASK_UP:
+			return GAMEPAD_JOYSTICK_MIN;
+
+		case GAMEPAD_MASK_DOWN:
+			return GAMEPAD_JOYSTICK_MAX;
+
+		default:
+			return GAMEPAD_JOYSTICK_MID;
 	}
 }
 
@@ -160,14 +163,17 @@ inline uint8_t runSOCDCleaner(SOCDMode mode, uint8_t dpad)
 			else
 				lastUD = DIRECTION_NONE;
 			break;
+
 		case GAMEPAD_MASK_UP:
 			newDpad |= GAMEPAD_MASK_UP;
 			lastUD = DIRECTION_UP;
 			break;
+
 		case GAMEPAD_MASK_DOWN:
 			newDpad |= GAMEPAD_MASK_DOWN;
 			lastUD = DIRECTION_DOWN;
 			break;
+
 		default:
 			lastUD = DIRECTION_NONE;
 			break;
@@ -181,14 +187,17 @@ inline uint8_t runSOCDCleaner(SOCDMode mode, uint8_t dpad)
 			else
 				lastLR = DIRECTION_NONE;
 			break;
+
 		case GAMEPAD_MASK_LEFT:
 			newDpad |= GAMEPAD_MASK_LEFT;
 			lastLR = DIRECTION_LEFT;
 			break;
+
 		case GAMEPAD_MASK_RIGHT:
 			newDpad |= GAMEPAD_MASK_RIGHT;
 			lastLR = DIRECTION_RIGHT;
 			break;
+
 		default:
 			lastLR = DIRECTION_NONE;
 			break;
@@ -196,5 +205,3 @@ inline uint8_t runSOCDCleaner(SOCDMode mode, uint8_t dpad)
 
 	return newDpad;
 }
-
-#endif

--- a/src/GamepadStorage.h
+++ b/src/GamepadStorage.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef GAMEPAD_STORAGE_H_
-#define GAMEPAD_STORAGE_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -15,13 +14,11 @@
 class GamepadStorage
 {
 	public:
-		virtual void start();
-		virtual void save();
+		virtual void start(); // TODO: Should be pure virtual.
+		virtual void save(); // TODO: Should be pure virtual.
 
 		GamepadOptions getGamepadOptions();
 		void setGamepadOptions(GamepadOptions options);
 };
 
 static GamepadStorage GamepadStore;
-
-#endif

--- a/src/MPG.cpp
+++ b/src/MPG.cpp
@@ -9,6 +9,7 @@ static HIDReport hidReport;
 static SwitchReport switchReport;
 static XInputReport xinputReport;
 
+
 void *MPG::getReport()
 {
 	switch (options.inputMode)
@@ -27,6 +28,7 @@ void *MPG::getReport()
 	}
 }
 
+
 uint16_t MPG::getReportSize()
 {
 	switch (options.inputMode)
@@ -42,9 +44,10 @@ uint16_t MPG::getReportSize()
 	}
 }
 
+
 HIDReport MPG::getHIDReport()
 {
-	HIDReport report =
+	HIDReport report
 	{
 		.buttons = 0,
 		.hat = HID_HAT_NOTHING,
@@ -87,9 +90,10 @@ HIDReport MPG::getHIDReport()
 	return report;
 }
 
+
 SwitchReport MPG::getSwitchReport()
 {
-	SwitchReport report =
+	SwitchReport report
 	{
 		.buttons = 0,
 		.hat = SWITCH_HAT_NOTHING,
@@ -133,9 +137,17 @@ SwitchReport MPG::getSwitchReport()
 	return report;
 }
 
+
 XInputReport MPG::getXInputReport()
 {
-	XInputReport report =
+	// NOTE: Had trouble coercing the compiler into accepting the conversion without declaring new variables
+	// to hold the values.
+	const int16_t lx = static_cast<int16_t>(state.lx) + INT16_MIN;
+	const int16_t ly = static_cast<int16_t>(~state.ly) + INT16_MIN;
+	const int16_t rx = static_cast<int16_t>(state.rx) + INT16_MIN;
+	const int16_t ry = static_cast<int16_t>(~state.ry) + INT16_MIN;
+
+	XInputReport report
 	{
 		.report_id = 0,
 		.report_size = XINPUT_ENDPOINT_SIZE,
@@ -143,10 +155,10 @@ XInputReport MPG::getXInputReport()
 		.buttons2 = 0,
 		.lt = state.lt,
 		.rt = state.rt,
-		.lx = state.lx + -32768,
-		.ly = ~(state.ly) + -32768,
-		.rx = state.rx + -32768,
-		.ry = ~(state.ry) + -32768,
+		.lx = lx,
+		.ly = ly,
+		.rx = rx,
+		.ry = ry,
 		._reserved = { },
 	};
 
@@ -184,6 +196,7 @@ XInputReport MPG::getXInputReport()
 
 	return report;
 }
+
 
 GamepadHotkey MPG::hotkey()
 {
@@ -251,6 +264,7 @@ GamepadHotkey MPG::hotkey()
 	return action;
 }
 
+
 void MPG::process()
 {
 	state.dpad = runSOCDCleaner(options.socdMode, state.dpad);
@@ -288,5 +302,4 @@ void MPG::process()
 			}
 			break;
 	}
-
 }

--- a/src/MPG.h
+++ b/src/MPG.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef MPG_H_
-#define MPG_H_
+#pragma once
 
 #include <stdio.h>
 #include <stdint.h>
@@ -27,7 +26,6 @@ class MPG
 			, f2Mask((GAMEPAD_MASK_L3 | GAMEPAD_MASK_R3))
 			, debouncer(debounceMS)
 		{
-
 		}
 
 		/**
@@ -48,53 +46,37 @@ class MPG
 		/**
 		 * @brief The current D-pad mode.
 		 */
-		GamepadOptions options =
-		{
-			.inputMode = InputMode::INPUT_MODE_XINPUT,
-			.dpadMode = DpadMode::DPAD_MODE_DIGITAL,
-			.socdMode = SOCDMode::SOCD_MODE_NEUTRAL,
-		};
+		GamepadOptions options;
 
 		/**
 		 * @brief The current gamepad state object.
 		 */
-		GamepadState state =
-		{
-			.dpad = 0,
-			.buttons = 0,
-			.aux = 0,
-			.lx = GAMEPAD_JOYSTICK_MID,
-			.ly = GAMEPAD_JOYSTICK_MID,
-			.rx = GAMEPAD_JOYSTICK_MID,
-			.ry = GAMEPAD_JOYSTICK_MID,
-			.lt = 0,
-			.rt = 0,
-		};
+		GamepadState state;
 
 		/**
 		 * @brief Flag to indicate analog trigger support.
 		 */
-		bool hasAnalogTriggers = false;
+		bool hasAnalogTriggers {false};
 
 		/**
 		 * @brief Flag to indicate Left analog stick support.
 		 */
-		bool hasLeftAnalogStick = false;
+		bool hasLeftAnalogStick {false};
 
 		/**
 		 * @brief Flag to indicate Right analog stick support.
 		 */
-		bool hasRightAnalogStick = false;
+		bool hasRightAnalogStick {false};
 
 		/**
-		 * @brief Perform pin setup and any other initialization the board requires
+		 * @brief Perform pin setup and any other initialization the board requires. Derived classes must overide this member.
 		 */
-		void setup();
+		virtual void setup() = 0;
 
 		/**
-		 * @brief Retrieve the inputs and save to the current state
+		 * @brief Retrieve the inputs and save to the current state. Derived classes must overide this member.
 		 */
-		void read();
+		virtual void read() = 0;
 
 		/**
 		 * @brief Checks and executes any hotkey being pressed.
@@ -111,7 +93,7 @@ class MPG
 		/**
 		 * @brief Process the inputs before sending state to host
 		 */
-		void process();
+		virtual void process();
 
 		/**
 		 * @brief Generate USB report for the current input mode.
@@ -185,5 +167,3 @@ class MPG
 		 */
 		GamepadDebouncer debouncer;
 };
-
-#endif

--- a/src/MPGS.h
+++ b/src/MPGS.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef MPGS_H_
-#define MPGS_H_
+#pragma once
 
 #include "MPG.h"
 #include "GamepadStorage.h"
@@ -15,16 +14,15 @@ class MPGS : public MPG
 		MPGS(int debounceMS = 5, GamepadStorage *storage = &GamepadStore)
 			: MPG(debounceMS), mpgStorage(storage)
 		{
-
 		}
 
 		/**
-		 * @brief Load the saved configuration from persitent storage.
+		 * @brief Load the saved configuration from persistent storage.
 		 */
 		void load();
 
 		/**
-		 * @brief Save the current configuration to persitent storage if changed.
+		 * @brief Save the current configuration to persistent storage if changed.
 		 */
 		void save();
 
@@ -36,7 +34,6 @@ class MPGS : public MPG
 		GamepadHotkey hotkey() override;
 
 	protected:
+		// TODO: bare pointers should be avoided when possible. Consider using shared_ptr or similar.
 		GamepadStorage *mpgStorage;
 };
-
-#endif

--- a/src/descriptors/HIDDescriptors.h
+++ b/src/descriptors/HIDDescriptors.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef HID_DESCRIPTORS_H_
-#define HID_DESCRIPTORS_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -42,7 +41,7 @@
 #define HID_JOYSTICK_MID 0x80
 #define HID_JOYSTICK_MAX 0xFF
 
-typedef struct __attribute((packed, aligned(1)))
+struct __attribute((packed, aligned(1))) HIDReport
 {
 	uint16_t buttons;
 	uint8_t hat;
@@ -50,7 +49,7 @@ typedef struct __attribute((packed, aligned(1)))
 	uint8_t ly;
 	uint8_t rx;
 	uint8_t ry;
-} HIDReport;
+};
 
 static const uint8_t hid_string_language[]     = { 0x09, 0x04 };
 static const uint8_t hid_string_manufacturer[] = "Generic";
@@ -128,7 +127,7 @@ static const uint8_t hid_configuration_descriptor[] =
 	0x81,        // bEndpointAddress (IN/D2H)
 	0x03,        // bmAttributes (Interrupt)
 	0x40, 0x00,  // wMaxPacketSize 64
-	0x01,        // bInterval 1 (unit depends on device speed)
+	0x01,        // bInterval 1 (unit depends on device speed) - NOTE: This is 125us on fast USB, which means it polls 8 times faster than the code responds.
 };
 
 static const uint8_t hid_report_descriptor[] =
@@ -174,5 +173,3 @@ static const uint8_t hid_report_descriptor[] =
 	0xB1, 0x02,        //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
 	0xC0,              // End Collection
 };
-
-#endif

--- a/src/descriptors/SwitchDescriptors.h
+++ b/src/descriptors/SwitchDescriptors.h
@@ -3,8 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef SWITCH_DESCRIPTORS_H_
-#define SWITCH_DESCRIPTORS_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -42,7 +41,7 @@
 #define SWITCH_JOYSTICK_MID 0x80
 #define SWITCH_JOYSTICK_MAX 0xFF
 
-typedef struct __attribute((packed, aligned(1)))
+struct __attribute((packed, aligned(1))) SwitchReport
 {
 	uint16_t buttons;
 	uint8_t hat;
@@ -51,9 +50,9 @@ typedef struct __attribute((packed, aligned(1)))
 	uint8_t rx;
 	uint8_t ry;
 	uint8_t vendor;
-} SwitchReport;
+};
 
-typedef struct
+struct SwitchOutReport
 {
 	uint16_t buttons;
 	uint8_t hat;
@@ -61,7 +60,7 @@ typedef struct
 	uint8_t ly;
 	uint8_t rx;
 	uint8_t ry;
-} SwitchOutReport;
+};
 
 static const uint8_t switch_string_language[]     = { 0x09, 0x04 };
 static const uint8_t switch_string_manufacturer[] = "HORI CO.,LTD.";
@@ -193,5 +192,3 @@ static const uint8_t switch_report_descriptor[] =
 	0x91, 0x02,        //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
 	0xC0,              // End Collection
 };
-
-#endif

--- a/src/descriptors/XInputDescriptors.h
+++ b/src/descriptors/XInputDescriptors.h
@@ -3,14 +3,14 @@
  * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
  */
 
-#ifndef XINPUT_DESCRIPTORS_H_
-#define XINPUT_DESCRIPTORS_H_
+#pragma once
 
 #include <stdint.h>
 
 #define XINPUT_ENDPOINT_SIZE 20
 
 // Buttons 1 (8 bits)
+// TODO: Consider using an enum class here.
 #define XBOX_MASK_UP    (1U << 0)
 #define XBOX_MASK_DOWN  (1U << 1)
 #define XBOX_MASK_LEFT  (1U << 2)
@@ -21,6 +21,7 @@
 #define XBOX_MASK_RS    (1U << 7)
 
 // Buttons 2 (8 bits)
+// TODO: Consider using an enum class here.
 #define XBOX_MASK_LB    (1U << 0)
 #define XBOX_MASK_RB    (1U << 1)
 #define XBOX_MASK_HOME  (1U << 2)
@@ -30,7 +31,7 @@
 #define XBOX_MASK_X     (1U << 6)
 #define XBOX_MASK_Y     (1U << 7)
 
-typedef struct __attribute((packed, aligned(1)))
+struct __attribute((packed, aligned(1))) XInputReport
 {
 	uint8_t report_id;
 	uint8_t report_size;
@@ -43,7 +44,7 @@ typedef struct __attribute((packed, aligned(1)))
 	int16_t rx;
 	int16_t ry;
 	uint8_t _reserved[6];
-} XInputReport;
+};
 
 static const uint8_t xinput_string_language[]    = { 0x09, 0x04 };
 static const uint8_t xinput_string_manfacturer[] = "Microsoft";
@@ -124,5 +125,3 @@ static const uint8_t xinput_configuration_descriptor[] =
 	0x20, 0x00,  // wMaxPacketSize 32
 	0x08,        // bInterval 8 (unit depends on device speed)
 };
-
-#endif


### PR DESCRIPTION
It's mostly just simple changes to make the code more modern or build without warnings. Built using the c++17 compiler. I used:

```
set(CMAKE_C_STANDARD 11)
set(CMAKE_CXX_STANDARD 17)
```

in my cmake file.

* warnings are all addressed
* switch implicit c style casts to static_cast for those ones I found
* left some notes on further improvements as TODO: and NOTE: labels in the code
* put initialisers in for some structs
* changed some struct declarations to the modern equivalent
* used #pragma once instead of old c style header protections
* removed a memcpy operation that seemed out of place
* switched some enum to use a common bitset declaration style for consistency
* added some whitespace in places, removed in others
* marked some members as pure virtual in line with their expected usage
* minor syntax modernisations

Code builds without errors or warnings, but I have not run tested it yet. There were very minimal code changes so I expect it should work fine.